### PR TITLE
link to hexdocs from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ def deps do
   ]
 end
 ```
+
+## Documentation
+
+API documentation is available at [https://hexdocs.pm/guardian_phoenix](https://hexdocs.pm/guardian_phoenix)


### PR DESCRIPTION
As the docs are on hexdocs, this commit adds a link to them from the readme.

Just like guardian, it's listed under a `Documentation` section.