### PR TITLE
Add Sockets doc link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ end
 
 ## Documentation
 
-API documentation is available at [https://hexdocs.pm/guardian_phoenix](https://hexdocs.pm/guardian_phoenix)
+API documentation is available at [hexdocs/guardian_phoenix](https://hexdocs.pm/guardian_phoenix/Guardian.Phoenix.Socket.html)


### PR DESCRIPTION
Hi, I'm not sure if this is a valid contribution, but I'm going to left it here as a suggestion.

I was digging into the repo looking for the documentation and I just realize that for now the only doc available is the `@moduledoc` from the Socket module (`socket.ex`).

And the hexdoc link on the README points to a page that states exactly the same thing as the README.
<img width="890" alt="Screen Shot 2021-02-25 at 23 28 17" src="https://user-images.githubusercontent.com/5873073/109246501-25b5d880-77c1-11eb-97dd-35e152194cd2.png">

Perhaps it would be more helpful to point the user to the Socket module hexdoc page.
